### PR TITLE
Add the integration test to set APIHost, Auth and Namespace

### DIFF
--- a/tests/src/integration/command_test.go
+++ b/tests/src/integration/command_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 var wsk *common.Wsk = common.NewWsk()
+var tmpProp = os.Getenv("GOPATH") + "/src/github.com/openwhisk/openwhisk-cli/wskprops.tmp"
 
 func TestHelpUsageInfoCommand(t *testing.T) {
 	stdout, err := wsk.RunCommand("-h")
@@ -39,6 +40,21 @@ func TestShowAPIVersion(t *testing.T) {
 	assert.Equal(t, nil, err, "The command property get --apiversion failed to run.")
 	assert.Contains(t, string(stdout), "whisk API version",
 		"The output of the command property get --apiversion does not contain \"whisk API version\".")
+}
+
+// Test case to verify the default namespace _.
+func TestDefaultNamespace(t *testing.T) {
+	common.CreateFile(tmpProp)
+	common.WriteFile(tmpProp, []string{"NAMESPACE="})
+
+	os.Setenv("WSK_CONFIG_FILE", tmpProp)
+	assert.Equal(t, os.Getenv("WSK_CONFIG_FILE"), tmpProp, "The environment variable WSK_CONFIG_FILE has not been set.")
+
+	stdout, err := wsk.RunCommand("property", "get", "-i", "--namespace")
+	assert.Equal(t, nil, err, "The command property get -i --namespace failed to run.")
+	assert.Contains(t, common.RemoveRedundentSpaces(string(stdout)), "whisk namespace _",
+		"The output of the command does not contain \"whisk namespace _\".")
+	common.DeleteFile(tmpProp)
 }
 
 

--- a/tests/src/integration/common/utils.go
+++ b/tests/src/integration/common/utils.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"regexp"
 )
 
 func checkError(err error) {
@@ -40,4 +41,11 @@ func WriteFile(filePath string, lines []string) {
 func DeleteFile(filePath string) {
 	var err = os.Remove(filePath)
 	checkError(err)
+}
+
+func RemoveRedundentSpaces(str string) string {
+	re_leadclose_whtsp := regexp.MustCompile(`^[\s\p{Zs}]+|[\s\p{Zs}]+$`)
+	re_inside_whtsp := regexp.MustCompile(`[\s\p{Zs}]{2,}`)
+	final := re_leadclose_whtsp.ReplaceAllString(str, "")
+	return re_inside_whtsp.ReplaceAllString(final, " ")
 }

--- a/tests/src/integration/common/wsk.go
+++ b/tests/src/integration/common/wsk.go
@@ -12,6 +12,7 @@ type Wsk struct {
 	Path string
 	Arg []string
 	Dir string
+	Wskprops *Wskprops
 }
 
 func NewWsk() *Wsk {
@@ -23,6 +24,7 @@ func NewWskWithPath(path string) *Wsk {
 	dep.Path = cmd
 	dep.Arg = []string{arg}
 	dep.Dir = path
+	dep.Wskprops = GetWskprops()
 	return &dep
 }
 
@@ -35,5 +37,6 @@ func (wsk *Wsk)RunCommand(s ...string) ([]byte, error) {
 }
 
 func (wsk *Wsk)ListNamespaces() ([]byte, error) {
-	return wsk.RunCommand("namespace", "list")
+	return wsk.RunCommand("namespace", "list", "--apihost", wsk.Wskprops.APIHost,
+		"--auth", wsk.Wskprops.AuthKey)
 }

--- a/tests/src/integration/common/wskprops.go
+++ b/tests/src/integration/common/wskprops.go
@@ -3,7 +3,6 @@ package common
 import (
 	"github.com/spf13/viper"
 	"io/ioutil"
-	"fmt"
 	"os"
 )
 
@@ -21,7 +20,6 @@ func GetWskprops() *Wskprops {
 	viper.AddConfigPath(os.Getenv("OPENWHISK_HOME"))
 
 	err := viper.ReadInConfig()
-	fmt.Println(err)
 	if err == nil {
 		authPath := viper.GetString("testing.auth")
 

--- a/tests/src/integration/integration_test.go
+++ b/tests/src/integration/integration_test.go
@@ -7,33 +7,34 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/openwhisk/openwhisk-cli/tests/src/integration/common"
 	"os"
+	"strings"
 )
 
 var wsk *common.Wsk = common.NewWsk()
 var tmpProp = os.Getenv("GOPATH") + "/src/github.com/openwhisk/openwhisk-cli/wskprops.tmp"
 
+// Test case to set apihost, auth, and namespace.
 func TestSetAPIHostAuthNamespace(t *testing.T) {
 	common.CreateFile(tmpProp)
 	common.WriteFile(tmpProp, []string{})
 
 	os.Setenv("WSK_CONFIG_FILE", tmpProp)
-	assert.Equal(t, os.Getenv("WSK_CONFIG_FILE"), tmpProp, "The environment variable WSK_CONFIG_FILE has not been set to de_DE.")
+	assert.Equal(t, os.Getenv("WSK_CONFIG_FILE"), tmpProp, "The environment variable WSK_CONFIG_FILE has not been set.")
 
-	//expectedNamespace, _ := wsk.ListNamespaces()
-	//fmt.Println(string(expectedNamespace))
-	wskprops := common.GetWskprops()
-	if (wskprops.APIHost != "" && wskprops.APIHost != "") {
-		stdout, err := wsk.RunCommand("property", "set", "-i", "--apihost", wskprops.APIHost, "--auth", wskprops.AuthKey)
-		//,
-		//	"--namespace", expectedNamespace)
+	namespace, _ := wsk.ListNamespaces()
+	namespaces := strings.Split(strings.TrimSpace(string(namespace)), "\n")
+	expectedNamespace := string(namespaces[len(namespaces)-1])
+	if (wsk.Wskprops.APIHost != "" && wsk.Wskprops.APIHost != "") {
+		stdout, err := wsk.RunCommand("property", "set", "-i", "--apihost", wsk.Wskprops.APIHost,
+			"--auth", wsk.Wskprops.AuthKey, "--namespace", expectedNamespace)
 		ouputString := string(stdout)
 		assert.Equal(t, nil, err, "The command property set --apihost --auth --namespace failed to run.")
-		assert.Contains(t, ouputString, "ok: whisk auth set to " + wskprops.AuthKey,
-			"The output of the command property get --apiversion does not contain \"whisk auth key setting\".")
-		assert.Contains(t, ouputString, "ok: whisk API host set to " + wskprops.APIHost,
-			"The output of the command property get --apiversion does not contain \"whisk API host setting\".")
-		//assert.Contains(t, ouputString, "ok: whisk namespace set to " + expectedNamespace,
-		//	"The output of the command does not contain \"whisk namespace setting\".")
+		assert.Contains(t, ouputString, "ok: whisk auth set to " + wsk.Wskprops.AuthKey,
+			"The output of the command property set --apihost --auth --namespace does not contain \"whisk auth key setting\".")
+		assert.Contains(t, ouputString, "ok: whisk API host set to " + wsk.Wskprops.APIHost,
+			"The output of the command property set --apihost --auth --namespace does not contain \"whisk API host setting\".")
+		assert.Contains(t, ouputString, "ok: whisk namespace set to " + expectedNamespace,
+			"The output of the command property set --apihost --auth --namespace does not contain \"whisk namespace setting\".")
 	}
 	common.DeleteFile(tmpProp)
 }


### PR DESCRIPTION
As the Travis CI has set up for Mac and Ubuntu, the openwhisk integration
tests and the native command tests can be continously added. This PR
adds the test to set APIHost, Auth and Namespace.