### PR TITLE
Add the binaries built for 32 bit

### DIFF
--- a/tools/travis/build_tag_releases.sh
+++ b/tools/travis/build_tag_releases.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 declare -a os_list=()
-arc=amd64
+declare -a arc_list=("amd64" "386")
 build_file_name=${1:-"wsk"}
 zip_file_name=${2:-"OpenWhisk_CLI"}
 os=$TRAVIS_OS_NAME
@@ -16,12 +16,19 @@ fi
 
 for os in "${os_list[@]}"
 do
-    wsk=$build_file_name
-    if [ "$os" == "windows" ]; then
-        wsk="$wsk.exe"
-    fi
-    cd $TRAVIS_BUILD_DIR
-    GOOS=$os GOARCH=$arc go build -o build/$os/$wsk
-    cd build/$os
-    zip -r "$TRAVIS_BUILD_DIR/$zip_file_name-$TRAVIS_TAG-$os-$arc.zip" $wsk
+    for arc in "${arc_list[@]}"
+    do
+        wsk=$build_file_name
+        os_name=$os
+        if [ "$os" == "windows" ]; then
+            wsk="$wsk.exe"
+        fi
+        if [ "$os" == "darwin" ]; then
+            os_name="mac"
+        fi
+        cd $TRAVIS_BUILD_DIR
+        GOOS=$os GOARCH=$arc go build -o build/$os/$arc/$wsk
+        cd build/$os/$arc
+        zip -r "$TRAVIS_BUILD_DIR/$zip_file_name-$TRAVIS_TAG-$os_name-$arc.zip" $wsk
+    done
 done


### PR DESCRIPTION
This PR adds the binaries built for 32 bit under mac, ubuntu and
windows. In addition, this PR changes the key word for mac from
darwin to mac to be consistent with the naming convention in
openwhisk cli gradle build.